### PR TITLE
Undefined ResultPath for Pass State Crashes

### DIFF
--- a/src/FakeStateMachine.ts
+++ b/src/FakeStateMachine.ts
@@ -96,7 +96,12 @@ export class FakeStateMachine {
       }
       case 'Pass': {
         const newValue = FakeStateMachine.runStatePass(state, data);
-        jsonpath.value(data, state.ResultPath, newValue);
+
+        if (state.ResultPath === undefined) {
+          Object.assign(data, newValue);
+        } else {
+          jsonpath.value(data, state.ResultPath, newValue);
+        }
         break;
       }
       case 'Succeed':

--- a/test/FakeStateMachine-run.ts
+++ b/test/FakeStateMachine-run.ts
@@ -49,6 +49,7 @@ describe('FakeStateMachine#run()', () => {
       );
     });
   });
+
   describe('when the state machine has two states', () => {
     test('should return the result successfully', async () => {
       const definition = require('./fixtures/definitions/two-states.json');
@@ -115,6 +116,30 @@ describe('FakeStateMachine#run()', () => {
           {
             a1: { b: 1 },
             a2: { b: 2 },
+          },
+          'Succeed',
+          null,
+          true
+        )
+      );
+    });
+  });
+
+  describe('when Pass state has undefined ResultPath', () => {
+    test('should not throw an Error', async () => {
+      const definition = require('./fixtures/definitions/pass-state-undefined-resultpath.json');
+      const fakeStateMachine = new FakeStateMachine(definition, {});
+
+      expect(
+        await fakeStateMachine.run({
+          changed: "TBD",
+          unchanged: "unchanged"
+        })
+      ).toEqual(
+        new RunStateResult(
+          {
+            changed: "changed by pass 0",
+            unchanged: "unchanged"
           },
           'Succeed',
           null,

--- a/test/FakeStateMachine-run.ts
+++ b/test/FakeStateMachine-run.ts
@@ -132,14 +132,14 @@ describe('FakeStateMachine#run()', () => {
 
       expect(
         await fakeStateMachine.run({
-          changed: "TBD",
-          unchanged: "unchanged"
+          changed: 'TBD',
+          unchanged: 'unchanged',
         })
       ).toEqual(
         new RunStateResult(
           {
-            changed: "changed by pass 0",
-            unchanged: "unchanged"
+            changed: 'changed by pass 0',
+            unchanged: 'unchanged',
           },
           'Succeed',
           null,

--- a/test/fixtures/definitions/pass-state-undefined-resultpath.json
+++ b/test/fixtures/definitions/pass-state-undefined-resultpath.json
@@ -1,0 +1,18 @@
+{
+  "StartAt": "Pass0",
+  "States": {
+    "Pass0": {
+      "Input": "changed by pass 0",
+      "ResultPath": "$.changed",
+      "Type": "Pass",
+      "Next": "Plaholder Pass State"
+    },
+    "Plaholder Pass State": {
+      "Type": "Pass",
+      "Next": "Done"
+    },
+    "Done": {
+      "Type": "Succeed"
+    }
+  }
+}


### PR DESCRIPTION
# Context
We use Pass states in our Step Functions to act as a placeholder to help with structuring in the AWS designer. However, when you review the generated asl the `ResultPath` for Pass States are only defined when you have set an valid value in the designer. 

Here is a generated asl which contains both a pass with a `ResultPath` and one without.

```json
{
  "StartAt": "Pass0",
  "States": {
    "Pass0": {
      "Input": "changed by pass 0",
      "ResultPath": "$.changed",
      "Type": "Pass",
      "Next": "Plaholder Pass State"
    },
    "Plaholder Pass State": {
      "Type": "Pass",
      "Next": "Done"
    },
    "Done": {
      "Type": "Succeed"
    }
  }
}
```

# Expected Behavior
The placeholder state should just pass the state through with no affect.

# Actual Behavior
You receive the following stack trace:
```
    assert(received)

    Expected value to be equal to:
      true
    Received:
      undefined

      we need a path

    Difference:

      Comparing two different types of values. Expected boolean but received undefined.

      at JSONPath.Object.<anonymous>.JSONPath.value (node_modules/jsonpath/lib/index.js:54:10)
      at FakeStateMachine.<anonymous> (node_modules/fake-step-functions/src/FakeStateMachine.ts:99:18)
      at node_modules/fake-step-functions/dist/FakeStateMachine.js:8:71
      at Object.<anonymous>.__awaiter (node_modules/fake-step-functions/dist/FakeStateMachine.js:4:12)
      at FakeStateMachine.runState (node_modules/fake-step-functions/dist/FakeStateMachine.js:53:16)
      at FakeStateMachine.<anonymous> (node_modules/fake-step-functions/src/FakeStateMachine.ts:51:31)
      at node_modules/fake-step-functions/dist/FakeStateMachine.js:8:71
      at Object.<anonymous>.__awaiter (node_modules/fake-step-functions/dist/FakeStateMachine.js:4:12)
      at FakeStateMachine.runPartial (node_modules/fake-step-functions/dist/FakeStateMachine.js:33:16)
      at FakeStateMachine.<anonymous> (node_modules/fake-step-functions/src/FakeStateMachine.ts:53:17)
      at fulfilled (node_modules/fake-step-functions/dist/FakeStateMachine.js:5:58)
```

# Cause
The OutputPath of a Pass state is undefined in the 
![image](https://user-images.githubusercontent.com/3812154/207337952-d4275deb-552d-44a0-bde9-e63422466a82.png)

# Fix
Similar to the Task state we should validate that the `state.ResultPath` is not undefined and then call `jsonpath.value`. If the `state.ResultPath` is undefined then use `Object.assign(data, newValue)` to pass through the data accordingly.
